### PR TITLE
Show the record not the current streak

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -2102,10 +2102,10 @@ void BlitMenuInfoIcon(u8 windowId, u8 iconId, u16 x, u16 y)
     BlitBitmapRectToWindow(windowId, &gMenuInfoElements_Gfx[sMenuInfoIcons[iconId].offset * 32], 0, 0, 128, 128, x, y, sMenuInfoIcons[iconId].width, sMenuInfoIcons[iconId].height);
 }
 
-// Duplication of function from /src/frontier_util.c
-static u16 FactoryGetWinStreak(u8 battleMode, u8 lvlMode)
+
+static u16 FactoryGetRecordWinStreak(u8 battleMode, u8 lvlMode)
 {
-    u16 winStreak = gSaveBlock2Ptr->frontier.factoryWinStreaks[battleMode][lvlMode];
+    u16 winStreak = gSaveBlock2Ptr->frontier.factoryRecordWinStreaks[battleMode][lvlMode];
     if (winStreak > MAX_STREAK)
         return MAX_STREAK;
     else
@@ -2157,11 +2157,11 @@ void BufferSaveMenuText(u8 textId, u8 *dest, u8 color)
             *endOfString = EOS;
             break;
         case SAVE_MENU_OL_REC:
-            record = FactoryGetWinStreak(FRONTIER_MODE_SINGLES, FRONTIER_LVL_OPEN);
+            record = FactoryGetRecordWinStreak(FRONTIER_MODE_SINGLES, FRONTIER_LVL_OPEN);
             string = ConvertIntToDecimalStringN(string, record, STR_CONV_MODE_RIGHT_ALIGN, 4);
             break;
         case SAVE_MENU_50_REC:
-            record = FactoryGetWinStreak(FRONTIER_MODE_SINGLES, FRONTIER_LVL_50);
+            record = FactoryGetRecordWinStreak(FRONTIER_MODE_SINGLES, FRONTIER_LVL_50);
             string = ConvertIntToDecimalStringN(string, record, STR_CONV_MODE_RIGHT_ALIGN, 4);
             break;
     }


### PR DESCRIPTION
This fixes the start/save display which was mistakenly showing the current/previous streaks rather than the record.