### PR TITLE
Prevent initial truck sequence from running within the factory

### DIFF
--- a/src/overworld.c
+++ b/src/overworld.c
@@ -1539,7 +1539,7 @@ void CB2_NewGame(void)
     PlayTimeCounter_Start();
     ScriptContext_Init();
     UnlockPlayerFieldControls();
-    gFieldCallback = ExecuteTruckSequence;
+    gFieldCallback = NULL;
     gFieldCallback2 = NULL;
     DoMapLoadLoop(&gMain.state);
     SetFieldVBlankCallback();


### PR DESCRIPTION
This change not only removes the initial visual glitches within the factory, but additionally lets the player move immediately instead of locking them in place until the sequence plays out.